### PR TITLE
fix: UOKiK post-filtering by NIP/REGON

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,6 +117,8 @@ def generate():
         detected_nip = _is_nip(query)
         detected_krs = not detected_nip and _is_krs(query)
     company_name: str | None = None
+    nip_for_uokik: str = ""
+    regon_for_uokik: str = ""
 
     # NIP → pobierz nazwę firmy z VAT (potrzebna dla name-based modułów)
     if detected_nip and any(m in selected for m in NAME_MODULES):
@@ -124,6 +126,8 @@ def generate():
             vat_result = vat.run(query, "nip")
             if vat_result.get("status") == "ok":
                 company_name = _shorten_for_search(vat_result["data"].get("nazwa", ""))
+                nip_for_uokik = vat_result["data"].get("nip", "") or ""
+                regon_for_uokik = vat_result["data"].get("regon", "") or ""
             if "vat" in selected:
                 results["vat"] = vat_result
         except Exception as e:
@@ -145,6 +149,8 @@ def generate():
 
         if name in NAME_MODULES:
             if company_name:
+                if name == "uokik":
+                    return uokik.run(company_name, "name", nip=nip_for_uokik, regon=regon_for_uokik)
                 return MODULES[name]["fn"](company_name, "name")
             # Brak nazwy (zapytanie to KRS lub nieznana forma) — pomiń
             if detected_krs or detected_nip:

--- a/modules/uokik.py
+++ b/modules/uokik.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import html
 import re
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed as _as_completed
 from urllib.parse import parse_qs, unquote, urljoin, urlparse
 import base64
 
@@ -140,17 +141,65 @@ def _shorten_name(name: str) -> str:
     return " ".join(words[:3])
 
 
-def run(query: str, query_type: str = "auto") -> dict:
+def _verify_decision(url: str, nip_clean: str, regon_clean: str) -> bool:
+    """Sprawdza czy strona decyzji zawiera NIP lub REGON podmiotu. Fail-open przy błędach."""
     try:
-        # Spróbuj pełną nazwą, potem skróconą jeśli brak wyników
+        resp = requests.get(
+            url,
+            headers={"User-Agent": "Mozilla/5.0", "Accept-Language": "pl-PL,pl;q=0.9"},
+            timeout=15,
+        )
+        if not resp.ok:
+            return True
+        text = re.sub(r"[\s\-]", "", resp.text)
+        if nip_clean and nip_clean in text:
+            return True
+        if regon_clean and regon_clean in text:
+            return True
+        return False
+    except Exception:
+        return True
+
+
+def _filter_by_nip_regon(results: list[dict], nip: str, regon: str) -> list[dict]:
+    """Filtruje wyniki — zachowuje decyzje, w których treści pojawia się NIP lub REGON."""
+    nip_clean = re.sub(r"[\s\-]", "", nip) if nip else ""
+    regon_clean = re.sub(r"[\s\-]", "", regon) if regon else ""
+    if not nip_clean and not regon_clean:
+        return results
+
+    verified: dict[str, bool] = {}
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(_verify_decision, r["url"], nip_clean, regon_clean): r["url"]
+            for r in results
+        }
+        for future in _as_completed(futures):
+            url = futures[future]
+            try:
+                verified[url] = future.result()
+            except Exception:
+                verified[url] = True  # fail-open
+
+    return [r for r in results if verified.get(r["url"], True)]
+
+
+def run(query: str, query_type: str = "auto", nip: str = "", regon: str = "") -> dict:
+    try:
         results = search(query)
         if not results and len(query.split()) > 2:
             short = _shorten_name(query)
             if short.lower() != query.lower():
                 results = search(short)
+
+        results = results[:20]
+
+        if results and (nip or regon):
+            results = _filter_by_nip_regon(results, nip, regon)
+
         return {
             "status": "ok" if results else "not_found",
-            "data": {"decisions": results[:20]},
+            "data": {"decisions": results},
         }
     except Exception as e:
         return {"status": "error", "error": str(e), "data": {}}


### PR DESCRIPTION
## Problem

Wyszukiwarka UOKiK działa wyłącznie po nazwie tekstowej, bez możliwości filtrowania po NIP/REGON. Dla firm o popularnych nazwach (np. zawierających słowa „WSB", „Merito", „Handel") zwracane były decyzje dotyczące zupełnie innych podmiotów (fałszywe trafienia).

## Rozwiązanie

Post-filtering: po pobraniu listy URL-i decyzji każda strona jest pobierana równolegle (max 8 wątków) i sprawdzana pod kątem obecności NIP lub REGON podmiotu. Decyzje, w których treści nie pojawia się żaden z tych identyfikatorów, są odrzucane.

**Zachowanie fail-open:** jeśli strona jest niedostępna lub zwraca błąd HTTP — decyzja jest zachowana (wysoki recall, akceptujemy ewentualne nadmiarowe wyniki zamiast ukrywać prawdziwe trafienia).

## Zmienione pliki

- `modules/uokik.py` — nowe funkcje `_verify_decision()` i `_filter_by_nip_regon()`, zaktualizowana sygnatura `run(nip="", regon="")`
- `app.py` — wyciąganie NIP/REGON z wyniku VAT i przekazywanie do `uokik.run()`

## Kiedy filtrowanie jest aktywne

Tylko gdy użytkownik podaje NIP i moduł VAT zwraca dane (wówczas NIP i REGON są znane). Przy zapytaniu po nazwie firmy lub KRS post-filtering jest pomijany — zachowane jest dotychczasowe zachowanie.

## Test plan

- [ ] NIP firmy o popularnej nazwie (np. WSB Merito `8942450411`) — sprawdzić czy liczba decyzji UOKiK spadła lub że pozostałe faktycznie dotyczą tego podmiotu
- [ ] NIP firmy, która faktycznie ma decyzję UOKiK — sprawdzić że nie zostaje odfiltrowana
- [ ] Zapytanie po nazwie (bez NIP) — sprawdzić że zachowanie bez zmian
- [ ] Zapytanie po KRS — sprawdzić że post-filtering nie jest uruchamiany

🤖 Generated with [Claude Code](https://claude.com/claude-code)