### PR TITLE
fix: KNF selector, cache, threading, font fallback, key mismatches

### DIFF
--- a/modules/knf.py
+++ b/modules/knf.py
@@ -1,17 +1,20 @@
 """KNF module - lista ostrzeżeń publicznych KNF."""
 
 from __future__ import annotations
+import threading
 import time
 from typing import Optional
 
 _cache: dict = {"data": None, "ts": 0.0}
+_cache_lock = threading.Lock()
 CACHE_TTL = 3600 * 6  # 6h
 
 
 def _get_all_warnings() -> list[dict]:
     now = time.time()
-    if _cache["data"] is not None and (now - _cache["ts"]) < CACHE_TTL:
-        return _cache["data"]
+    with _cache_lock:
+        if _cache["data"] is not None and (now - _cache["ts"]) < CACHE_TTL:
+            return _cache["data"]
 
     from playwright.sync_api import sync_playwright
     with sync_playwright() as p:
@@ -23,7 +26,7 @@ def _get_all_warnings() -> list[dict]:
 
         data = []
         for table in page.query_selector_all("table.warning-list-table"):
-            for row in table.query_selector_all("tr.warning-row"):
+            for row in table.query_selector_all("tr"):
                 tds = row.query_selector_all("td")
                 if len(tds) == 6:
                     data.append({
@@ -36,8 +39,11 @@ def _get_all_warnings() -> list[dict]:
                     })
         browser.close()
 
-    _cache["data"] = data
-    _cache["ts"] = now
+    # don't cache empty results - page may not have loaded properly
+    if data:
+        with _cache_lock:
+            _cache["data"] = data
+            _cache["ts"] = now
     return data
 
 

--- a/modules/powiazania.py
+++ b/modules/powiazania.py
@@ -91,7 +91,8 @@ def _check_entity_in_knf(name: str) -> dict:
     from modules import knf
     try:
         r = knf.run(name, "name")
-        hit = r.get("status") == "ok" and bool(r.get("data", {}).get("warnings"))
+        knf_data = r.get("data", {})
+        hit = r.get("status") == "ok" and bool(knf_data.get("matches") or knf_data.get("found"))
         return {"status": r.get("status"), "hit": hit}
     except Exception as e:
         return {"status": "error", "error": str(e), "hit": False}

--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -41,10 +41,11 @@ def calculate(results: dict) -> dict:
     # KNF
     knf = results.get("knf", {})
     if knf.get("status") == "ok":
-        warnings = knf.get("data", {}).get("warnings", [])
-        if warnings:
+        knf_data = knf.get("data", {})
+        matches = knf_data.get("matches", [])
+        if matches or knf_data.get("found"):
             score += WEIGHTS["knf_hit"]
-            reasons.append(f"Podmiot figuruje na liście ostrzeżeń KNF ({len(warnings)} wpis/ów)")
+            reasons.append(f"Podmiot figuruje na liście ostrzeżeń KNF ({len(matches)} wpis/ów)")
 
     # UOKiK
     uokik = results.get("uokik", {})

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -57,8 +57,8 @@ def _register_fonts():
 
 
 _UNICODE_FONTS = _register_fonts()
-FONT_REGULAR = "UniFont" if _UNICODE_FONTS else FONT_REGULAR
-FONT_BOLD    = "UniFont-Bold" if _UNICODE_FONTS else FONT_BOLD
+FONT_REGULAR = "UniFont" if _UNICODE_FONTS else "Helvetica"
+FONT_BOLD    = "UniFont-Bold" if _UNICODE_FONTS else "Helvetica-Bold"
 FONT_ITALIC  = FONT_REGULAR  # no separate oblique variant
 
 


### PR DESCRIPTION
Fixes that didn't make it into main before PR #28 was merged.

- `knf.py`: `tr.warning-row` → `tr` (class no longer exists on KNF page); don't cache empty results; add `threading.Lock`
- `scoring.py` + `powiazania.py`: `data.warnings` → `data.matches` — KNF hit was never triggering the score penalty
- `pdf_generator.py`: font fallback referenced undefined `FONT_REGULAR`/`FONT_BOLD` causing `NameError` on machines without font files

🤖 Generated with [Claude Code](https://claude.com/claude-code)