### PR TITLE
fix: KNF/UOKiK fallback to NIP when VAT fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,11 +126,17 @@ def generate():
         if name == "powiazania":
             return powiazania.run(query, "nip")
         if name in NAME_MODULES:
-            if not company_name:
-                return {"status": "skipped", "error": "Brak nazwy firmy — moduł VAT nie zwrócił danych.", "data": {}}
+            if name == "rekrutacje":
+                if not company_name:
+                    return {"status": "skipped", "error": "Brak nazwy firmy — moduł VAT nie zwrócił danych.", "data": {}}
+                return MODULES["rekrutacje"]["fn"](company_name, "name")
+            # KNF i UOKiK: jeśli VAT nie dał nazwy, szukaj po NIP bezpośrednio
+            # KNF sprawdza NIP w polu KRS na liście ostrzeżeń, więc działa
+            search_q = company_name if company_name else query
+            search_type = "name" if company_name else "nip"
             if name == "uokik":
-                return uokik.run(company_name, "name", nip=nip_for_uokik, regon=regon_for_uokik)
-            return MODULES[name]["fn"](company_name, "name")
+                return uokik.run(search_q, search_type, nip=nip_for_uokik or query, regon=regon_for_uokik)
+            return MODULES[name]["fn"](search_q, search_type)
         return MODULES[name]["fn"](query, "nip")
 
     remaining = [n for n in selected if n not in results]

--- a/modules/rekrutacje.py
+++ b/modules/rekrutacje.py
@@ -164,7 +164,8 @@ def _fetch_justjoinit(keyword: str) -> list[dict]:
     )
     data = resp.json().get("data", [])
 
-    # filter client-side to exact company
+    # JustJoin.it ignores the companyName param - filter client-side
+    # In practice this returns 0 results because the API returns unrelated companies
     offers = []
     for o in data:
         if kw_lower not in (o.get("companyName") or "").lower():
@@ -193,6 +194,8 @@ def _fetch_justjoinit(keyword: str) -> list[dict]:
 
 
 def _scrape_justjoinit(keyword: str) -> list[dict]:
+    # JustJoin.it API does not support filtering by employer - companyName param is ignored
+    # All attempts (REST API, Playwright) return unfiltered results or empty page
     return _fetch_justjoinit(keyword)
 
 


### PR DESCRIPTION
When VAT module doesn't return company data, KNF and UOKiK are now called
with the NIP directly instead of being skipped entirely.

KNF works because the warning list stores NIP in the KRS field — direct
NIP search matches correctly. UOKiK falls back to NIP search too.
Rekrutacje still requires a company name and keeps the skip behavior.

Also notes JustJoin.it API limitation (companyName param is ignored by
their API, always returns 0 company-specific results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)